### PR TITLE
Check if account already linked to address

### DIFF
--- a/src/ParachainStaking.sol
+++ b/src/ParachainStaking.sol
@@ -40,6 +40,7 @@ contract ParachainStaking is Parachain {
 
     mapping(address => StakeInfo) private stakerDetails; // mapping from a persons address to their staking info
     mapping(uint32 => mapping(address => ParachainStakeInfo)) private parachainStakerDetails;
+    mapping(uint32 => mapping(bytes => address)) private paraAccountToAddress; // mapping from a parachain account to a staker address
 
     // Structs
     struct Report {
@@ -117,9 +118,16 @@ contract ParachainStaking is Parachain {
         // Ensure parachain is registered
         IRegistry.Parachain memory parachain = registry.getById(_paraId);
         require(parachain.owner != address(0x0), "parachain not registered");
+        // Ensure account is not linked to another staker
+        require(
+            paraAccountToAddress[_paraId][_account] == address(0x0)
+                || paraAccountToAddress[_paraId][_account] == msg.sender,
+            "account already linked to another staker"
+        );
 
         ParachainStakeInfo storage _parachainStakeInfo = parachainStakerDetails[_paraId][msg.sender];
         _parachainStakeInfo._account = _account;
+        paraAccountToAddress[_paraId][_account] = msg.sender;
 
         StakeInfo storage _staker = _parachainStakeInfo._stakeInfo;
         uint256 _lockedBalance = _staker.lockedBalance;


### PR DESCRIPTION
- Ensures only one oracle consumer parachain account can be linked to one EVM address. 
- Adds `paraAccountToAddress ` mapping, adds a require statement in `depositParachainStake`, updates test.
- There is the possibility of people camping addresses, but this risk doesn't seem to pose too much downside. And someone can always link a different account and transfer funds if their originally-intended account is already linked.
- Closes #35 