### PR TITLE
Fix func param type & remove unneeded one

### DIFF
--- a/src/Parachain.sol
+++ b/src/Parachain.sol
@@ -69,9 +69,12 @@ abstract contract Parachain {
     /// @param _reporter address The corresponding address of the reporter on the parachain.
     /// @param _recipient address The address of the recipient of the slashed stake.
     /// @param _amount uint256 Amount slashed.
-    function reportSlash(IRegistry.Parachain memory _parachain, bytes memory _reporter, address _recipient, uint256 _amount)
-        internal
-    {
+    function reportSlash(
+        IRegistry.Parachain memory _parachain,
+        bytes memory _reporter,
+        address _recipient,
+        uint256 _amount
+    ) internal {
         uint64 transactRequiredWeightAtMost = 5000000000;
         bytes memory call = abi.encodePacked(
             _parachain.palletInstance, // pallet index within parachain runtime
@@ -89,7 +92,9 @@ abstract contract Parachain {
     /// @param _parachain Para The registered parachain.
     /// @param _reporter address Address of staker on EVM compatible chain w/ Tellor controller contracts.
     /// @param _amount uint256 Amount withdrawn.
-    function reportStakeWithdrawn(IRegistry.Parachain memory _parachain, bytes memory _reporter, uint256 _amount) internal {
+    function reportStakeWithdrawn(IRegistry.Parachain memory _parachain, bytes memory _reporter, uint256 _amount)
+        internal
+    {
         uint64 transactRequiredWeightAtMost = 5000000000;
         bytes memory call = abi.encodePacked(
             _parachain.palletInstance, // pallet index within runtime

--- a/src/Parachain.sol
+++ b/src/Parachain.sol
@@ -64,23 +64,16 @@ abstract contract Parachain {
         transactThroughSigned(_parachain.id, transactRequiredWeightAtMost, call, feeAmount, overallWeight);
     }
 
-    /// @dev Report slash to a registered parachain.
+    /// @dev Report slash to a registered parachain. Recipient will always be the governance contract.
     /// @param _parachain Para The registered parachain.
     /// @param _reporter address The corresponding address of the reporter on the parachain.
-    /// @param _recipient address The address of the recipient of the slashed stake.
     /// @param _amount uint256 Amount slashed.
-    function reportSlash(
-        IRegistry.Parachain memory _parachain,
-        bytes memory _reporter,
-        address _recipient,
-        uint256 _amount
-    ) internal {
+    function reportSlash(IRegistry.Parachain memory _parachain, bytes memory _reporter, uint256 _amount) internal {
         uint64 transactRequiredWeightAtMost = 5000000000;
         bytes memory call = abi.encodePacked(
             _parachain.palletInstance, // pallet index within parachain runtime
             hex"0F", // fixed call index within pallet: 15
             _reporter, // account id of reporter on target parachain
-            _recipient, // recipient
             bytes32(reverse(_amount)) // amount
         );
         uint256 feeAmount = 10000000000;

--- a/src/ParachainStaking.sol
+++ b/src/ParachainStaking.sol
@@ -225,7 +225,7 @@ contract ParachainStaking is Parachain {
      * @param _recipient is the address receiving the reporter's stake
      * @return _slashAmount uint256 amount of token slashed and sent to recipient address
      */
-    function slashParachainReporter(uint256 _slashAmount, uint32 _paraId, bytes memory _reporter, address _recipient)
+    function slashParachainReporter(uint256 _slashAmount, uint32 _paraId, address _reporter, address _recipient)
         external
         returns (uint256)
     {
@@ -259,7 +259,12 @@ contract ParachainStaking is Parachain {
         require(token.transfer(_recipient, _slashAmount), "transfer failed");
         emit ParachainReporterSlashed(_paraId, _reporter, _recipient, _slashAmount);
 
-        reportSlash(parachain, _reporter, _recipient, _slashAmount);
+        reportSlash(
+            parachain,
+            _parachainStakeInfo._account, // reporter's account on oracle consumer parachain
+            _recipient,
+            _slashAmount
+        );
         return _slashAmount;
     }
 

--- a/src/ParachainStaking.sol
+++ b/src/ParachainStaking.sol
@@ -214,7 +214,11 @@ contract ParachainStaking is Parachain {
         emit StakeWithdrawn(msg.sender);
         emit ParachainStakeWithdrawn(_paraId, msg.sender);
 
-        reportStakeWithdrawn(parachain, abi.encodePacked(msg.sender), _amount);
+        reportStakeWithdrawn(
+            parachain,
+            _parachainStakeInfo._account, // staker's linked account on oracle consumer parachain
+            _amount
+        );
     }
 
     /**

--- a/src/ParachainStaking.sol
+++ b/src/ParachainStaking.sol
@@ -262,7 +262,6 @@ contract ParachainStaking is Parachain {
         reportSlash(
             parachain,
             _parachainStakeInfo._account, // reporter's account on oracle consumer parachain
-            _recipient,
             _slashAmount
         );
         return _slashAmount;

--- a/test/helpers/TestParachain.sol
+++ b/test/helpers/TestParachain.sol
@@ -24,13 +24,10 @@ contract TestParachain is Parachain {
         reportStakeWithdrawRequested(_parachain, _account, _amount, _staker);
     }
 
-    function reportSlashExternal(
-        IRegistry.Parachain memory _parachain,
-        bytes memory _reporter,
-        address _recipient,
-        uint256 _amount
-    ) external {
-        reportSlash(_parachain, abi.encodePacked(_reporter), _recipient, _amount);
+    function reportSlashExternal(IRegistry.Parachain memory _parachain, bytes memory _reporter, uint256 _amount)
+        external
+    {
+        reportSlash(_parachain, abi.encodePacked(_reporter), _amount);
     }
 
     function reportStakeWithdrawnExternal(

--- a/test/helpers/TestParachain.sol
+++ b/test/helpers/TestParachain.sol
@@ -33,9 +33,11 @@ contract TestParachain is Parachain {
         reportSlash(_parachain, abi.encodePacked(_reporter), _recipient, _amount);
     }
 
-    function reportStakeWithdrawnExternal(IRegistry.Parachain memory _parachain, bytes memory _reporter, uint256 _amount)
-        external
-    {
+    function reportStakeWithdrawnExternal(
+        IRegistry.Parachain memory _parachain,
+        bytes memory _reporter,
+        uint256 _amount
+    ) external {
         reportStakeWithdrawn(_parachain, _reporter, _amount);
     }
 

--- a/test/helpers/TestParachain.sol
+++ b/test/helpers/TestParachain.sol
@@ -27,7 +27,7 @@ contract TestParachain is Parachain {
     function reportSlashExternal(IRegistry.Parachain memory _parachain, bytes memory _reporter, uint256 _amount)
         external
     {
-        reportSlash(_parachain, abi.encodePacked(_reporter), _amount);
+        reportSlash(_parachain, _reporter, _amount);
     }
 
     function reportStakeWithdrawnExternal(

--- a/test/testParachain.t.sol
+++ b/test/testParachain.t.sol
@@ -22,7 +22,7 @@ contract ParachainTest is Test {
     address public paraDisputer = address(0x2222);
     address public fakeStakingContract = address(0x9999);
     address fakeStaker = address(0xabcd);
-    bytes fakeReporter = abi.encode(fakeStaker);
+    bytes fakeReporter = abi.encode(fakeStaker); // fake reporter account on oracle consumer parachain
 
     // Parachain registration
     uint32 public fakeParaId = 12;
@@ -145,7 +145,7 @@ contract ParachainTest is Test {
 
         // test registered parachain
         vm.prank(fakeStakingContract);
-        parachain.reportSlashExternal(fakeParachain, fakeStaker, paraDisputer, fakeAmount);
+        parachain.reportSlashExternal(fakeParachain, fakeReporter, paraDisputer, fakeAmount);
 
         // check saved data passed to StubXcmTransactorV2 through transactThroughSigned
         StubXcmTransactorV2.TransactThroughSignedMultilocationCall[] memory savedDataArray =
@@ -162,7 +162,7 @@ contract ParachainTest is Test {
         bytes memory call = abi.encodePacked(
             abi.encode(fakePalletInstance),
             hex"0F",
-            fakeStaker,
+            fakeReporter,
             paraDisputer,
             bytes32(parachain.reverseExternal(fakeAmount))
         );
@@ -182,7 +182,7 @@ contract ParachainTest is Test {
 
         // test registered parachain
         vm.prank(fakeStakingContract);
-        parachain.reportStakeWithdrawnExternal(fakeParachain, fakeStaker, fakeAmount);
+        parachain.reportStakeWithdrawnExternal(fakeParachain, fakeReporter, fakeAmount);
 
         // check saved data passed to StubXcmTransactorV2 through transactThroughSigned
         StubXcmTransactorV2.TransactThroughSignedMultilocationCall[] memory savedDataArray =
@@ -197,7 +197,7 @@ contract ParachainTest is Test {
         assertEq(savedData.feeLocation.interior[0], abi.encodePacked(hex"00", bytes4(fakeParaId)));
         assertEq(savedData.transactRequiredWeightAtMost, 5000000000);
         bytes memory call = abi.encodePacked(
-            abi.encode(fakePalletInstance), hex"0E", fakeStaker, bytes32(parachain.reverseExternal(fakeAmount))
+            abi.encode(fakePalletInstance), hex"0E", fakeReporter, bytes32(parachain.reverseExternal(fakeAmount))
         );
         assertEq(savedData.call, call);
         assertEq(savedData.feeAmount, 10000000000);
@@ -214,7 +214,7 @@ contract ParachainTest is Test {
 
         uint256 fakeAmount = 100e18;
         vm.prank(fakeStakingContract);
-        parachain.reportStakeWithdrawnExternal(fakeParachain, fakeStaker, fakeAmount);
+        parachain.reportStakeWithdrawnExternal(fakeParachain, fakeReporter, fakeAmount);
 
         // check saved data passed to StubXcmTransactorV2 through transactThroughSigned
         StubXcmTransactorV2.TransactThroughSignedMultilocationCall[] memory savedDataArray =
@@ -232,7 +232,7 @@ contract ParachainTest is Test {
 
         uint256 fakeAmount = 100e18;
         vm.prank(fakeStakingContract);
-        parachain.reportStakeWithdrawnExternal(fakeParachain, fakeStaker, fakeAmount);
+        parachain.reportStakeWithdrawnExternal(fakeParachain, fakeReporter, fakeAmount);
 
         // check saved data passed to StubXcmTransactorV2 through transactThroughSigned
         StubXcmTransactorV2.TransactThroughSignedMultilocationCall[] memory savedDataArray =

--- a/test/testParachain.t.sol
+++ b/test/testParachain.t.sol
@@ -145,7 +145,7 @@ contract ParachainTest is Test {
 
         // test registered parachain
         vm.prank(fakeStakingContract);
-        parachain.reportSlashExternal(fakeParachain, fakeReporter, paraDisputer, fakeAmount);
+        parachain.reportSlashExternal(fakeParachain, fakeReporter, fakeAmount);
 
         // check saved data passed to StubXcmTransactorV2 through transactThroughSigned
         StubXcmTransactorV2.TransactThroughSignedMultilocationCall[] memory savedDataArray =
@@ -160,11 +160,7 @@ contract ParachainTest is Test {
         assertEq(savedData.feeLocation.interior[0], abi.encodePacked(hex"00", bytes4(fakeParaId)));
         assertEq(savedData.transactRequiredWeightAtMost, 5000000000);
         bytes memory call = abi.encodePacked(
-            abi.encode(fakePalletInstance),
-            hex"0F",
-            fakeReporter,
-            paraDisputer,
-            bytes32(parachain.reverseExternal(fakeAmount))
+            abi.encode(fakePalletInstance), hex"0F", fakeReporter, bytes32(parachain.reverseExternal(fakeAmount))
         );
         assertEq(savedData.call, call);
         assertEq(savedData.feeAmount, 10000000000);


### PR DESCRIPTION
- Builds off @Jayrajrodage 's work
- Closes #51 
- Also removes `_recipient` parameter from `reportSlash`, as the recipient will always be the gov contract