### PR TITLE
Update slash reporter function to handle zero balance case

### DIFF
--- a/src/Parachain.sol
+++ b/src/Parachain.sol
@@ -219,11 +219,7 @@ abstract contract Parachain {
     /// @dev Converts provided weight to fee for XCM execution.
     /// @param overallWeight uint256 Combined weight of consumer chain's dispatchable function (wrapped in transact) and XCM instructions.
     /// @param weightToFee uint256 Fee per weight (constant multiplier)
-    function convertWeightToFee(uint256 overallWeight, uint256 weightToFee)
-        internal
-        pure
-        returns (uint256)
-    {
+    function convertWeightToFee(uint256 overallWeight, uint256 weightToFee) internal pure returns (uint256) {
         // overall xcm fee cost based on constantMultiplier
         return overallWeight * weightToFee;
     }

--- a/src/ParachainGovernance.sol
+++ b/src/ParachainGovernance.sol
@@ -213,7 +213,7 @@ contract ParachainGovernance is Parachain {
         }
         emit Voted(
             _thisDispute.paraId, _thisDispute.queryId, _thisDispute.timestamp, _supports, msg.sender, _validDispute
-        );
+            );
     }
 
     /**
@@ -264,7 +264,7 @@ contract ParachainGovernance is Parachain {
             _totalReportsFor,
             _totalReportsAgainst,
             _totalReportsInvalid
-        );
+            );
     }
 
     /**

--- a/src/ParachainStaking.sol
+++ b/src/ParachainStaking.sol
@@ -244,7 +244,6 @@ contract ParachainStaking is Parachain {
         StakeInfo storage _staker = _parachainStakeInfo._stakeInfo;
         uint256 _stakedBalance = _staker.stakedBalance;
         uint256 _lockedBalance = _staker.lockedBalance;
-        require(_stakedBalance + _lockedBalance > 0, "zero staker balance");
         if (_lockedBalance >= _slashAmount) {
             // if locked balance is at least _slashAmount, slash from locked balance
             _staker.lockedBalance -= _slashAmount;

--- a/src/ParachainStaking.sol
+++ b/src/ParachainStaking.sol
@@ -262,14 +262,16 @@ contract ParachainStaking is Parachain {
             _staker.stakedBalance = 0;
             _staker.lockedBalance = 0;
         }
-        require(token.transfer(_recipient, _slashAmount), "transfer failed");
-        emit ParachainReporterSlashed(_paraId, _reporter, _recipient, _slashAmount);
+        if (_slashAmount > 0) {
+            require(token.transfer(_recipient, _slashAmount), "transfer failed");
+            emit ParachainReporterSlashed(_paraId, _reporter, _recipient, _slashAmount);
 
-        reportSlash(
-            parachain,
-            _parachainStakeInfo._account, // reporter's account on oracle consumer parachain
-            _slashAmount
-        );
+            reportSlash(
+                parachain,
+                _parachainStakeInfo._account, // reporter's account on oracle consumer parachain
+                _slashAmount
+            );
+        }
         return _slashAmount;
     }
 

--- a/test/helpers/StubXcmTransactorV2.sol
+++ b/test/helpers/StubXcmTransactorV2.sol
@@ -95,7 +95,7 @@ contract StubXcmTransactorV2 is XcmTransactorV2 {
     ) external override {
         emit TransactThroughSigned(
             dest, feeLocationAddress, transactRequiredWeightAtMost, call, feeAmount, overallWeight
-        );
+            );
     }
 
     // add this to be excluded from coverage report

--- a/test/helpers/TestParachain.sol
+++ b/test/helpers/TestParachain.sol
@@ -46,11 +46,7 @@ contract TestParachain is Parachain {
         return x1(_paraId);
     }
 
-    function convertWeightToFeeExternal(uint256 overallWeight, uint256 weightToFee)
-        external
-        pure
-        returns (uint256)
-    {
+    function convertWeightToFeeExternal(uint256 overallWeight, uint256 weightToFee) external pure returns (uint256) {
         return convertWeightToFee(overallWeight, weightToFee);
     }
 }

--- a/test/testParachainStaking.t.sol
+++ b/test/testParachainStaking.t.sol
@@ -388,15 +388,15 @@ contract ParachainStakingTest is Test {
             paraDisputer // _recipient
         );
 
-        // Attempt to slash when zero staked/locked
+        // Slash when zero staked/locked
         vm.prank(staking.governance());
-        vm.expectRevert("zero staker balance");
-        staking.slashParachainReporter(
+        uint256 _slashAmount = staking.slashParachainReporter(
             10, // _slashAmount
             fakeParaId, // _paraId
             address(0x1234), // _reporter
             paraDisputer // _recipient
         );
+        assertEq(_slashAmount, 0);
 
         // Deposit stake
         vm.startPrank(paraOwner);


### PR DESCRIPTION
- Closes #67 
- If a dispute is started on the pallet side, `beginParachainDispute` is called in the gov contract, which calls `slashParachainReporter`. If the disputed reporter has a total balance of zero, then the slash amount is updated to zero, no slash event is emitted, no transfer is attempted, and `reportSlash` isn't called.
- Some files were formatted using `forge fmt`