### PR TITLE
Remove and handle remaining todos

### DIFF
--- a/src/ParachainRegistry.sol
+++ b/src/ParachainRegistry.sol
@@ -18,7 +18,6 @@ interface IRegistry {
     }
 
     //    todo: suggestion to replace these with simpler below functions, so state only read once per outer calling function
-    //    todo: confirm that using struct via memory does indeed pass by reference for internal functions
     //    function owner(uint32 _paraId) external view returns(address);
     //    function palletInstance(uint32 _paraId) external view returns(bytes memory);
     //    function stakeAmount(uint32 _paraId) external view returns(uint256);
@@ -70,12 +69,10 @@ contract ParachainRegistry is IRegistry {
     }
 
     function getById(uint32 _id) external view override returns (Parachain memory) {
-        // todo: confirm this creates a copy which is then passed around by reference within consuming functions
         return registrations[owners[_id]];
     }
 
     function getByAddress(address _address) external view override returns (Parachain memory) {
-        // todo: confirm this creates a copy which is then passed around by reference within consuming functions
         return registrations[_address];
     }
 

--- a/src/ParachainRegistry.sol
+++ b/src/ParachainRegistry.sol
@@ -4,10 +4,6 @@ pragma solidity ^0.8.0;
 import "../lib/moonbeam/precompiles/XcmTransactorV2.sol";
 import "../lib/moonbeam/precompiles/XcmUtils.sol";
 
-// error NotAllowed();
-// error NotOwner();
-// error ParachainNotRegistered();
-
 interface IRegistry {
     struct Parachain {
         uint32 id;
@@ -17,17 +13,11 @@ interface IRegistry {
         XcmTransactorV2.Multilocation feeLocation;
     }
 
-    //    todo: suggestion to replace these with simpler below functions, so state only read once per outer calling function
-    //    function owner(uint32 _paraId) external view returns(address);
-    //    function palletInstance(uint32 _paraId) external view returns(bytes memory);
-    //    function stakeAmount(uint32 _paraId) external view returns(uint256);
-
     function getById(uint32 _id) external view returns (Parachain memory);
     function getByAddress(address _address) external view returns (Parachain memory);
 }
 
 contract ParachainRegistry is IRegistry {
-    // todo: confirm optimisation for lookups based on parachain owner address over paraId
     mapping(address => Parachain) private registrations;
     mapping(uint32 => address) private owners;
 
@@ -50,9 +40,7 @@ contract ParachainRegistry is IRegistry {
         // Ensure sender is on parachain
         address derivativeAddress =
             xcmUtils.multilocationToAddress(XcmUtils.Multilocation(1, x2(_paraId, _palletInstance)));
-        // if (msg.sender != derivativeAddress) revert NotOwner();
         require(msg.sender == derivativeAddress, "Not owner");
-        // todo: consider effects of changing pallet instance with re-registration
         registrations[msg.sender] =
             Parachain(_paraId, msg.sender, abi.encodePacked(_palletInstance), _weightToFee, _feeLocation);
         owners[_paraId] = msg.sender;
@@ -64,8 +52,6 @@ contract ParachainRegistry is IRegistry {
         // Ensure parachain is registered & sender is parachain owner
         IRegistry.Parachain memory _parachain = registrations[msg.sender];
         require(_parachain.owner == msg.sender && _parachain.owner != address(0x0), "not owner");
-
-        // todo: remove registrations after considering effects on existing stake/disputes etc.
     }
 
     function getById(uint32 _id) external view override returns (Parachain memory) {
@@ -78,14 +64,11 @@ contract ParachainRegistry is IRegistry {
 
     function parachain(uint32 _paraId) private pure returns (bytes memory) {
         // 0x00 denotes Parachain: https://docs.moonbeam.network/builders/xcm/xcm-transactor/#building-the-precompile-multilocation
-        // return bytes.concat(hex"00", bytes4(_paraId));
-        // TypeError: Member "concat" not found or not visible after argument-dependent lookup in type(bytes storage pointer)
         return abi.encodePacked(hex"00", abi.encodePacked(_paraId));
     }
 
     function pallet(uint8 _palletInstance) private pure returns (bytes memory) {
         // 0x04 denotes PalletInstance: https://docs.moonbeam.network/builders/xcm/xcm-transactor/#building-the-precompile-multilocation
-        // return bytes.concat(hex"04", bytes1(_palletInstance));
         return abi.encodePacked(hex"04", abi.encodePacked(_palletInstance));
     }
 

--- a/test/testE2E.t.sol
+++ b/test/testE2E.t.sol
@@ -256,6 +256,10 @@ contract E2ETests is Test {
 
         // Stake, then request stake withdrawal
         uint256 initialBalance = token.balanceOf(address(bob));
+        (, uint256 stakedBalance, uint256 lockedBalance) = staking.getParachainStakerInfo(fakeParaId, bob);
+        console.log("starting stakedBalance: %s", stakedBalance);
+        console.log("starting lockedBalance: %s", lockedBalance);
+        console.log("starting bob balance: %s", token.balanceOf(address(bob)));
         vm.startPrank(bob);
         token.approve(address(staking), fakeStakeAmount);
         staking.depositParachainStake(
@@ -263,12 +267,19 @@ contract E2ETests is Test {
             bytes("consumerChainAcct"), // _account
             fakeStakeAmount // _amount
         );
+        (, stakedBalance, lockedBalance) = staking.getParachainStakerInfo(fakeParaId, bob);
+        console.log("after staking stakedBalance: %s", stakedBalance);
+        console.log("after staking lockedBalance: %s", lockedBalance);
+        console.log("after staking bob balance: %s", token.balanceOf(address(bob)));
         staking.requestParachainStakeWithdraw(
             fakeParaId, // _paraId
             fakeStakeAmount // _amount
         );
         vm.stopPrank();
-        (, uint256 stakedBalance, uint256 lockedBalance) = staking.getParachainStakerInfo(fakeParaId, bob);
+        (, stakedBalance, lockedBalance) = staking.getParachainStakerInfo(fakeParaId, bob);
+        console.log("after withdraw request stakedBalance: %s", stakedBalance);
+        console.log("after withdraw request lockedBalance: %s", lockedBalance);
+        console.log("after withdraw request bob balance: %s", token.balanceOf(address(bob)));
         assertEq(lockedBalance, fakeStakeAmount);
         assertEq(stakedBalance, fakeStakeAmount);
         assertEq(token.balanceOf(address(bob)), initialBalance - fakeStakeAmount);
@@ -282,15 +293,15 @@ contract E2ETests is Test {
         );
         // Check reporter was slashed
         (, uint256 _stakedBalAfter, uint256 _lockedBalAfter) = staking.getParachainStakerInfo(fakeParaId, bob);
+        console.log("after dispute stakedBalance: %s", _stakedBalAfter);
+        console.log("after dispute lockedBalance: %s", _lockedBalAfter);
+        console.log("after dispute bob balance: %s", token.balanceOf(address(bob)));
         assertEq(_stakedBalAfter, fakeStakeAmount);
         assertEq(token.balanceOf(address(bob)), initialBalance - fakeStakeAmount);
         assertEq(_lockedBalAfter, fakeStakeAmount - fakeSlashAmount);
 
         assertEq(token.balanceOf(address(staking)), 50);
         assertEq(token.balanceOf(address(gov)), fakeSlashAmount);
-
-        // todo: what if the slash amount is more than the stake amount?
-        // todo: check if stake amount is supposed to remain the same after requesting withdrawal & slashed from dispute
     }
 
     function testMultipleStakeWithdrawRequestsDisputesOnMultipleChains() public {
@@ -408,7 +419,7 @@ contract E2ETests is Test {
         balanceGovContract = token.balanceOf(address(gov));
         console.log("Staking contract balance after dispute for 2nd parachain: ", balanceStakingContract);
         console.log("Gov contract balance after dispute for 2nd parachain: ", balanceGovContract);
-        assertEq(balanceStakingContract, (fakeStakeAmount + fakeStakeAmount2) - fakeSlashAmount * 2); // todo: check if this is correct
+        assertEq(balanceStakingContract, (fakeStakeAmount + fakeStakeAmount2) - fakeSlashAmount * 2);
         assertEq(balanceGovContract, fakeSlashAmount * 2);
         console.log("\n");
 

--- a/test/testParachainGovernance.t.sol
+++ b/test/testParachainGovernance.t.sol
@@ -391,8 +391,6 @@ contract ParachainGovernanceTest is Test {
         vm.expectRevert("Vote must be tallied");
         gov.executeVote(realDisputeId);
 
-        // todo: unsure how to test "Must be the final vote"
-
         // Tally votes
         uint256 tallyDate = block.timestamp + 7 days;
         vm.warp(tallyDate);


### PR DESCRIPTION
- Closes #74 
- Closes #21 
- To-dos asking to confirm if a copy the `Parachain` struct is created and passed by reference is correct, as the struct is declared as memory and and consuming functions which also declare it as memory will receive it by reference.
- Removed `deregister` to-do, as covered in #76 
- Removed re-register to-do, as covered in #77
- Removed optimization to-do, as covered in #78